### PR TITLE
using same branch cause I am a moron - CORS

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,6 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
+django-cors-headers = "*"
 
 [dev-packages]
 

--- a/manage.py
+++ b/manage.py
@@ -14,7 +14,7 @@ def main():
             "Couldn't import Django. Are you sure it's installed and "
             "available on your PYTHONPATH environment variable? Did you "
             "forget to activate a virtual environment?"
-        ) from exc
+        )
     execute_from_command_line(sys.argv)
 
 

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'debug_toolbar',
+    'corsheaders',
 ]
 
 MIDDLEWARE = [
@@ -49,8 +50,13 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
+    'django.middleware.common.CommonMiddleware',
     'debug_toolbar.middleware.DebugToolbarMiddleware',
 ]
+
+CORS_ALLOW_ALL_ORIGINS = True # If this is used then `CORS_ALLOWED_ORIGINS` will not have any effect
+CORS_ALLOW_CREDENTIALS = True
 
 ROOT_URLCONF = 'mysite.urls'
 


### PR DESCRIPTION
- Quick server side addition to add CORS package to allow API calls from browser
- If you looked at browser console during angular runtime, you would see failed API calls due to CORs (even though the API route does not exist yet. You will get CORS error before 404, because it resolves the header before the API route is actually hit). 
- I am using PIPENV to run this, so I installed Cors to my pipfile.lock as a pipenv dependency. So if you are using your host machine you can remove the pipfile lock and just install in raw pip. 